### PR TITLE
Use slice::iter instead of into_iter to avoid future breakage

### DIFF
--- a/src/tail.rs
+++ b/src/tail.rs
@@ -68,8 +68,8 @@ impl<'a> IntoIterator for Tail<'a>{
     type IntoIter = ::std::slice::Iter<'a,Bracket>;
     fn into_iter(self)->Self::IntoIter{
         match self {
-            Tail::Rest(v)=>v.into_iter(),
-            _=>EMPTY_B_SLICE.into_iter(),
+            Tail::Rest(v)=>v.iter(),
+            _=>EMPTY_B_SLICE.iter(),
                   
         }
     }


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.